### PR TITLE
Keep environment variables on command execution

### DIFF
--- a/src/executors/commandExecutor.ts
+++ b/src/executors/commandExecutor.ts
@@ -10,7 +10,7 @@ export class CommandExecutor {
 
     constructor(cwd: string = null, env: object = {}) {
         this._cwd = cwd;
-        this._env = env;
+        this._env = {...process.env, ...env};
 
         if ('onDidCloseTerminal' in <any>vscode.window) {
             (<any>vscode.window).onDidCloseTerminal((terminal) => {


### PR DESCRIPTION
When setting the `env` parameter on `child_process.exec()` the parent's environment gets overridden.
In order to pass down the parent's environment variables (like `DOCKER_HOST`) to the spawned process, `process.env` needs to be merged in with any new environment variables.

This should make this extension work for setups where `DOCKER_HOST` needs to be set (e.g. accessing Docker for Windows from within WSL). @dmlb2000 reported this before as issue #32.