### PR TITLE
Accept `yaml` extension (and `compose.yml`)

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ The extension contributes the following settings:
 * `docker-compose.autoRefreshInterval`: Interval (in milliseconds) to auto-refresh containers list. Set 0 to disable auto-refresh. (Default is `10000`)
 * `docker-compose.projectNames`: Override Docker Compose project name for each workspace root (Default is basename of the workspace directory).
 * `docker-compose.showExplorer`: Show Docker Compose explorer view. (Default is `True`)
-* `docker-compose.files`: Docker Compose files. You can define array of files. (Default is `["docker-compose.yml"]`).
+* `docker-compose.files`: Docker Compose files. You can define array of files. (Default is `["compose.yaml", "compose.yml", "docker-compose.yaml", "docker-compose.yml"]`).
 * `docker-compose.shell`: Specify shell to use inside Docker Container. (Default is `"/bin/sh"`).
 
 ## Known Issues

--- a/package.json
+++ b/package.json
@@ -28,6 +28,9 @@
     "url": "https://github.com/p1c2u/vscode-docker-compose.git"
   },
   "activationEvents": [
+    "workspaceContains:**/compose.yaml",
+    "workspaceContains:**/compose.yml",
+    "workspaceContains:**/docker-compose.yaml",
     "workspaceContains:**/docker-compose.yml",
     "onCommand:docker-compose.explorer.refresh",
     "onCommand:docker-compose.project.start",

--- a/package.json
+++ b/package.json
@@ -318,6 +318,9 @@
             "type": "string"
           },
           "default": [
+            "compose.yaml",
+            "compose.yml",
+            "docker-compose.yaml",
             "docker-compose.yml"
           ],
           "description": "Specify Docker Compose files."

--- a/package.json
+++ b/package.json
@@ -320,12 +320,7 @@
           "items": {
             "type": "string"
           },
-          "default": [
-            "compose.yaml",
-            "compose.yml",
-            "docker-compose.yaml",
-            "docker-compose.yml"
-          ],
+          "default": [],
           "description": "Specify Docker Compose files."
         }
       }


### PR DESCRIPTION
The [documentation of `docker-compose`][1] explicitly says that implementations should look for files named `compose.yaml` (preferred), `compose.yml`, `docker-compose.yaml` or `docker-compose.yml`.

[1] https://github.com/compose-spec/compose-spec/blob/master/spec.md#compose-file

Fixes #37.